### PR TITLE
[CHORE] Simplify/remove mutation from updateTaskDefinitionImage

### DIFF
--- a/test.js
+++ b/test.js
@@ -140,7 +140,7 @@ describe('ECS Service Image Updater', function() {
     };
 
     var updatedTaskDefinition = updater.updateTaskDefinitionImage(taskDefinition, container, image);
-    expect(updatedTaskDefinition['containerDefinitions'][0]['image']).to.equal(image);
+    expect(updatedTaskDefinition[0]['image']).to.equal(image);
   });
 
   it('updateTaskDefinitionImage should update a task definition with a new image in multiple containers', function() {
@@ -166,9 +166,9 @@ describe('ECS Service Image Updater', function() {
     };
 
     var updatedTaskDefinition = updater.updateTaskDefinitionImage(taskDefinition, ['app', 'worker'], newImage);
-    expect(updatedTaskDefinition['containerDefinitions'][0]['image']).to.equal(newImage);
-    expect(updatedTaskDefinition['containerDefinitions'][1]['image']).to.equal(newImage);
-    expect(updatedTaskDefinition['containerDefinitions'][2]['image']).to.equal(oldImage);
+    expect(updatedTaskDefinition[0]['image']).to.equal(newImage);
+    expect(updatedTaskDefinition[1]['image']).to.equal(newImage);
+    expect(updatedTaskDefinition[2]['image']).to.equal(oldImage);
   });
 
   it('createTaskDefinition should register new task definition', function(done) {


### PR DESCRIPTION
I was trying to debug an issue and noticed this code was a little confusing and relied on mutation. WDYT @coen-hyde 