### PR TITLE
New option to wait for completed deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Options:
   --cluster-arn             Arn of the ECS Cluster for which the Service exists
                             on. Used in conjunction with service-name
   --output-arn-only         Output the new Task Definition Arn only
+  --wait-interval           Poll service deployment status at interval (seconds) and wait for completed deployment
+  --verbose-deployment      Output deployment progress to console (requires wait-interval)
 ```
 
 ### Examples

--- a/bin/ecs-service-image-updater
+++ b/bin/ecs-service-image-updater
@@ -2,6 +2,7 @@
 'use strict'
 
 const updater = require('../');
+const waiter = require('../waiter');
 
 var argv = require('yargs')
   .describe('image', 'Docker image and tag')
@@ -11,6 +12,8 @@ var argv = require('yargs')
   .describe('task-definition-family', 'Task Definition Family create the new Task Definition in')
   .describe('cluster-arn', 'Arn of the ECS Cluster for which the Service exists on. Used in conjunction with service-name')
   .describe('output-arn-only', 'Output the new Task Definition Arn only')
+  .describe('wait-interval', 'Poll service deployment status at interval (seconds) and wait for completed deployment')
+  .describe('verbose-deployment', 'Output deployment progress to console (requires wait-interval)')
   .demand([ 'image' ])
   .implies('service-name', 'cluster-arn')
   .conflicts('container-name', 'container-names')
@@ -43,6 +46,16 @@ updater(options, (err, taskDefinitionArn) => {
 
   if (argv.serviceName) {
     console.log(`Service ${argv.serviceName} has been updated to use the new Task Definition`);
-    return;
+    if (argv.waitInterval) {
+      waiter({
+        serviceName: options.serviceName,
+        clusterArn: options.clusterArn,
+        taskDefinitionArn: taskDefinitionArn,
+        interval: argv.waitInterval,
+        verbose: argv.verboseDeployment
+      }, function (err) {
+        if (err) throw err;
+      })
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecs-service-image-updater",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Update an ECS service with a new Docker image",
   "main": "index.js",
   "scripts": {

--- a/waiter.js
+++ b/waiter.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const AWS = require('aws-sdk');
+const _ = require('lodash');
+
+// Set the default region to 'us-east-1' if not already set
+if (!AWS.config.region) {
+    AWS.config.update({
+        region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+    });
+}
+
+/**
+ *
+ * @param options
+ * @param {int} options.interval
+ * @param {boolean} options.verbose
+ * @param {string} options.serviceName
+ * @param {string} options.clusterArn
+ * @param {string} options.taskDefinitionArn
+ * @param {function} cb
+ */
+function waiter(options, cb) {
+    /**
+     * getServiceTaskDeployments
+     *
+     * Retrieve the active Task Definition Arn on a service
+     * @param {object} options A hash of options used when initiating this deployment
+     * @param {function} cb Callback
+     */
+    function getServiceTaskDeployments(options, cb) {
+        const ecs = new AWS.ECS();
+
+        const params = {
+            cluster: options.clusterArn,
+            services: [options.serviceName]
+        };
+
+        ecs.describeServices(params, (err, data) => {
+            if (err) return cb(err);
+
+            var service = _.find(data.services, (s) => s.serviceName === options.serviceName);
+            if (!service) return cb(new Error(`Could not find service "${options.serviceName}"`));
+
+            cb(null, service.deployments);
+        });
+    }
+
+    function periodicCheck() {
+        getServiceTaskDeployments(options, function (err, deployments) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            const isCurrent = deployments.filter(deployment => deployment.taskDefinition === options.taskDefinitionArn).length === 1;
+
+            if (!isCurrent) {
+                console.log(`Task definition "${options.taskDefinitionArn}" for service "${options.serviceName}" is no longer deploying`)
+                return;
+            }
+            if (deployments.length === 1) {
+                console.log(`Task definition "${options.taskDefinitionArn}" for service "${options.serviceName}" is deployed`)
+                return;
+            }
+
+            if (options.verbose) {
+                let output = '[';
+                deployments.map(function (deployment) {
+                    if (deployment.taskDefinition === options.taskDefinitionArn) {
+                        output += 'X'.repeat(deployment.runningCount);
+                        output += 'x'.repeat(deployment.pendingCount);
+                    } else {
+                        output += '.'.repeat(deployment.runningCount);
+                    }
+                })
+                output += ']';
+                console.log(output);
+            }
+
+            setTimeout(periodicCheck, options.interval * 1000);
+        })
+    }
+
+    setTimeout(periodicCheck, 2 * 1000);
+
+}
+
+module.exports = waiter;


### PR DESCRIPTION
I have added option to wait for completed deployment. It is useful for CI integrations - for example GitLab reports deployment as completed as soon as CI job finishes and that is confusing because deployment on AWS side is still running.

It checks service status at defined interval until there is only new taskArn deployed if it is not listed in deployments at all (service was reverted or there was another deployment). I have also added simple task count "animation" to show how is deployment progressing.

I did my best to match existing code style but I didn't manage to come up with tests yet.