### PR TITLE
[INF-2535] Add Github CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push]
+
+jobs:
+    test:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/setup-node@v3
+          with:
+            node-version: 18.x
+        - run: npm ci
+        - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Update an ECS service with a new Docker image",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha --recursive"
+    "test": "mocha --recursive"
   },
   "bin": {
     "ecs-service-image-updater": "./bin/ecs-service-image-updater"


### PR DESCRIPTION
Was going to start on migrating this to the AWS SDK v3 but it has no CI setup just yet. This also gets in the way of validating that any Dependabot PRs are safe to merge.