### PR TITLE
[INF-2535] Remove use of async

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ const options = {
   image: 'image:tag'
 }
 
-updater(options, (err, taskDefinitionArn) => {
-  if (err) throw err;
-  console.log('done');
-});
+updater(options)
+  .then((taskDefinitionArn) => {
+    console.log(`Done. New task definition: ${taskDefinitionArn}`);
+  })
+  .catch((err) => {
+    console.log(err);
+  });
 ```

--- a/bin/ecs-service-image-updater
+++ b/bin/ecs-service-image-updater
@@ -31,21 +31,21 @@ if (argv.containerName) options.containerNames = [argv.containerName];
 if (argv.serviceName) options.serviceName = argv.serviceName;
 if (argv.taskDefinitionFamily) options.taskDefinitionFamily = argv.taskDefinitionFamily;
 
-updater(options, (err, taskDefinitionArn) => {
-  if (err) {
+updater(options)
+  .then((taskDefinitionArn) => {
+    if (argv.outputArnOnly) {
+      console.log(taskDefinitionArn);
+      return;
+    }
+
+    console.log(`Created Task Definition: ${taskDefinitionArn}`);
+
+    if (argv.serviceName) {
+      console.log(`Service ${argv.serviceName} has been updated to use the new Task Definition`);
+      return;
+    }
+  })
+  .catch((err) => {
     console.log(err.toString());
     process.exit(1);
-  }
-
-  if (argv.outputArnOnly) {
-    console.log(taskDefinitionArn);
-    return;
-  }
-
-  console.log(`Created Task Definition: ${taskDefinitionArn}`);
-
-  if (argv.serviceName) {
-    console.log(`Service ${argv.serviceName} has been updated to use the new Task Definition`);
-    return;
-  }
-});
+  });

--- a/bin/ecs-service-image-updater
+++ b/bin/ecs-service-image-updater
@@ -32,7 +32,10 @@ if (argv.serviceName) options.serviceName = argv.serviceName;
 if (argv.taskDefinitionFamily) options.taskDefinitionFamily = argv.taskDefinitionFamily;
 
 updater(options, (err, taskDefinitionArn) => {
-  if (err) throw err;
+  if (err) {
+    console.log(err.toString());
+    process.exit(1);
+  }
 
   if (argv.outputArnOnly) {
     console.log(taskDefinitionArn);

--- a/index.js
+++ b/index.js
@@ -13,12 +13,12 @@ const region = process.env.AWS_DEFAULT_REGION || 'us-east-1';
  * @param {object} options A hash of options used when initiating this deployment
  * @return {Promise}
  */
-const updater = function (options, cb) {
+const updater = function (options) {
   const ecs = new ECS({ region: region });
 
   let taskDefinitionArn; // preserve this in the outer scope
 
-  updater.currentTaskDefinition(options)
+  return updater.currentTaskDefinition(options)
     .then((currentTaskDefinition) => {
       const newTaskDefinition = updater.updateTaskDefinitionImage(
         currentTaskDefinition,
@@ -34,9 +34,8 @@ const updater = function (options, cb) {
 
       return updater.updateService(options, taskDefinitionArn)
     })
-    .then(_service => cb(null, taskDefinitionArn))
-    .catch(err => cb(err));
-}
+    .then(_service => taskDefinitionArn);
+};
 
 Object.assign(updater, {
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ecs": "^3.454.0",
-        "async": "^3.2.0",
         "lodash": "^4.17.19",
         "yargs": "^15.0.2"
       },
@@ -1225,11 +1224,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "node_modules/aws-sdk-client-mock": {
       "version": "3.0.0",
@@ -3403,11 +3397,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "async": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "aws-sdk-client-mock": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-service-image-updater",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-service-image-updater",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ecs": "^3.454.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/bugcrowd/ecs-service-image-updater#readme",
   "dependencies": {
     "@aws-sdk/client-ecs": "^3.454.0",
-    "async": "^3.2.0",
     "lodash": "^4.17.19",
     "yargs": "^15.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-service-image-updater",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Update an ECS service with a new Docker image",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -25,18 +25,8 @@ describe('ECS Service Image Updater', function () {
     const serviceName = 'planet-express';
     const taskDefinitionArn = 'arn::good-news:96';
 
-    updater.getServiceTaskDefinition = function (options, cb) {
-      return cb(null, taskDefinitionArn);
-    };
-
-    updater.getLatestActiveTaskDefinition = function (options, cb) {
-      // should never be called
-      expect(false).to.equal(true);
-    };
-
-    updater.getTaskDefinition = function (taskDefinitionArnSupplied, cb) {
-      return cb(null, { taskDefinitionArn: taskDefinitionArn });
-    };
+    updater.getServiceTaskDefinition = () => Promise.resolve(taskDefinitionArn);
+    updater.getTaskDefinition = _taskDefinitionArnSupplied => Promise.resolve({ taskDefinitionArn: taskDefinitionArn });
 
     updater.currentTaskDefinition({ serviceName: serviceName }, function (err, taskDefinition) {
       expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
@@ -48,18 +38,8 @@ describe('ECS Service Image Updater', function () {
     const family = 'simpsons';
     const taskDefinitionArn = 'arn::good-news:96';
 
-    updater.getServiceTaskDefinition = function (options, cb) {
-      // should never be called
-      expect(false).to.equal(true);
-    };
-
-    updater.getLatestActiveTaskDefinition = function (options, cb) {
-      return cb(null, taskDefinitionArn);
-    };
-
-    updater.getTaskDefinition = function (taskDefinitionArnSupplied, cb) {
-      return cb(null, { taskDefinitionArn: taskDefinitionArn });
-    };
+    updater.getLatestActiveTaskDefinition = () => Promise.resolve(taskDefinitionArn);
+    updater.getTaskDefinition = _taskDefinitionArnSupplied => Promise.resolve({ taskDefinitionArn: taskDefinitionArn });
 
     updater.currentTaskDefinition({ taskDefinitionFamily: family }, function (err, taskDefintion) {
       expect(taskDefintion.taskDefinitionArn).to.equal(taskDefinitionArn);
@@ -83,10 +63,11 @@ describe('ECS Service Image Updater', function () {
       return Promise.resolve(data);
     });
 
-    updater.getServiceTaskDefinition({ serviceName: serviceName }, function (err, taskDefinitionArnReturned) {
-      expect(taskDefinitionArnReturned).to.equal(taskDefinitionArn);
-      done();
-    });
+    updater.getServiceTaskDefinition({ serviceName: serviceName })
+      .then((taskDefinitionArnReturned) => {
+        expect(taskDefinitionArnReturned).to.equal(taskDefinitionArn);
+        done();
+      });
   });
 
   it('getLatestActiveTaskDefinition should get the latest task definition in a Task Definition Family', function (done) {
@@ -108,10 +89,11 @@ describe('ECS Service Image Updater', function () {
       return Promise.resolve(data);
     });
 
-    updater.getLatestActiveTaskDefinition({ taskDefinitionFamily: family }, function (err, taskDefintionArnReturned) {
-      expect(taskDefintionArnReturned).to.equal("arn:2");
-      done();
-    });
+    updater.getLatestActiveTaskDefinition({ taskDefinitionFamily: family })
+      .then((taskDefinitionArnReturned) => {
+        expect(taskDefinitionArnReturned).to.equal("arn:2");
+        done();
+      });
   });
 
   it('getTaskDefinition should return a task definition', function (done) {
@@ -122,10 +104,11 @@ describe('ECS Service Image Updater', function () {
       return Promise.resolve({ taskDefinition: { taskDefinitionArn: taskDefinitionArn } });
     });
 
-    updater.getTaskDefinition(taskDefinitionArn, function (err, taskDefintion) {
-      expect(taskDefintion.taskDefinitionArn).to.equal(taskDefinitionArn);
-      done();
-    });
+    updater.getTaskDefinition(taskDefinitionArn)
+      .then((taskDefinition) => {
+        expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
+        done();
+      });
   });
 
   it('updateTaskDefinitionImage should update a task definition with a new image', function () {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,14 @@
 'use strict'
 
 const expect = require('expect.js');
-const { ECS, DescribeServicesCommand, ListTaskDefinitionsCommand, DescribeTaskDefinitionCommand, RegisterTaskDefinitionCommand, UpdateServiceCommand } = require('@aws-sdk/client-ecs');
+const {
+  ECS,
+  DescribeServicesCommand,
+  ListTaskDefinitionsCommand,
+  DescribeTaskDefinitionCommand,
+  RegisterTaskDefinitionCommand,
+  UpdateServiceCommand
+} = require('@aws-sdk/client-ecs');
 const { mockClient } = require('aws-sdk-client-mock');
 
 const updater = require('./');
@@ -26,12 +33,13 @@ describe('ECS Service Image Updater', function () {
     const taskDefinitionArn = 'arn::good-news:96';
 
     updater.getServiceTaskDefinition = () => Promise.resolve(taskDefinitionArn);
-    updater.getTaskDefinition = _taskDefinitionArnSupplied => Promise.resolve({ taskDefinitionArn: taskDefinitionArn });
+    updater.getTaskDefinition = () => Promise.resolve({ taskDefinitionArn: taskDefinitionArn });
 
-    updater.currentTaskDefinition({ serviceName: serviceName }, function (err, taskDefinition) {
-      expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
-      done();
-    });
+    updater.currentTaskDefinition({ serviceName: serviceName })
+      .then((taskDefinition) => {
+        expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
+        done();
+      });
   });
 
   it('currentTaskDefinition should return the current task definition in a Task Definition Family', function (done) {
@@ -41,10 +49,11 @@ describe('ECS Service Image Updater', function () {
     updater.getLatestActiveTaskDefinition = () => Promise.resolve(taskDefinitionArn);
     updater.getTaskDefinition = _taskDefinitionArnSupplied => Promise.resolve({ taskDefinitionArn: taskDefinitionArn });
 
-    updater.currentTaskDefinition({ taskDefinitionFamily: family }, function (err, taskDefintion) {
-      expect(taskDefintion.taskDefinitionArn).to.equal(taskDefinitionArn);
-      done();
-    });
+    updater.currentTaskDefinition({ taskDefinitionFamily: family })
+      .then((taskDefinition) => {
+        expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
+        done();
+      });
   });
 
   it('getServiceTaskDefinition should get the active task definition in Service', function (done) {
@@ -192,9 +201,9 @@ describe('ECS Service Image Updater', function () {
     });
 
     it('should do it all more good', function (done) {
-      updater.currentTaskDefinition = function (optionsSupplied, cb) {
+      updater.currentTaskDefinition = (optionsSupplied) => {
         expect(optionsSupplied).to.eql(options);
-        cb(null, { taskDefinitionArn: 'arn' });
+        return Promise.resolve({ taskDefinitionArn: 'arn' });
       };
 
       updater.updateTaskDefinitionImage = function (taskDefinition, containerName, image) {

--- a/test.js
+++ b/test.js
@@ -231,10 +231,8 @@ describe('ECS Service Image Updater', function () {
         return Promise.resolve({ taskDefinition: 'arn:created' });
       }
 
-      updater(options, (err, deploy) => {
-        expect(err).to.equal(null);
-        done();
-      });
+      updater(options)
+        .then(() => done());
     });
   });
 });

--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const path = require('path');
 const expect = require('expect.js');
 const { ECS, DescribeServicesCommand, ListTaskDefinitionsCommand, DescribeTaskDefinitionCommand, RegisterTaskDefinitionCommand, UpdateServiceCommand } = require('@aws-sdk/client-ecs');
 const { mockClient } = require('aws-sdk-client-mock');
@@ -39,8 +38,8 @@ describe('ECS Service Image Updater', function () {
       return cb(null, { taskDefinitionArn: taskDefinitionArn });
     };
 
-    updater.currentTaskDefinition({ serviceName: serviceName }, function (err, taskDefintion) {
-      expect(taskDefintion.taskDefinitionArn).to.equal(taskDefinitionArn);
+    updater.currentTaskDefinition({ serviceName: serviceName }, function (err, taskDefinition) {
+      expect(taskDefinition.taskDefinitionArn).to.equal(taskDefinitionArn);
       done();
     });
   });

--- a/test.js
+++ b/test.js
@@ -194,6 +194,13 @@ describe('ECS Service Image Updater', function () {
     const oldUpdateTaskDefinitionImageFn = updater.updateTaskDefinitionImage;
     const oldUpdateServiceFn = updater.updateService;
 
+    const options = {
+      clusterArn: 'arn:cluster',
+      serviceName: 'serviceName',
+      containerNames: ['containerName'],
+      image: 'image:1'
+    };
+
     after(() => {
       updater.currentTaskDefinition = oldCurrentTaskDefinitionFn;
       updater.updateTaskDefinitionImage = oldUpdateTaskDefinitionImageFn;
@@ -222,13 +229,6 @@ describe('ECS Service Image Updater', function () {
         expect(optionsSupplied).to.eql(options);
         expect(taskDefinitionArn).to.equal('arn:created');
         return Promise.resolve({ taskDefinition: 'arn:created' });
-      }
-
-      const options = {
-        clusterArn: 'arn:cluster',
-        serviceName: 'serviceName',
-        containerNames: ['containerName'],
-        image: 'image:1'
       }
 
       updater(options, (err, deploy) => {

--- a/test.js
+++ b/test.js
@@ -173,11 +173,11 @@ describe('ECS Service Image Updater', function () {
       serviceName: 'serviceName',
     };
 
-    updater.updateService(options, 'arn:taskDefinition', (err, service) => {
-      expect(err).to.equal(null);
-      expect(service).to.eql({ serviceName: 'serviceName' });
-      done();
-    });
+    updater.updateService(options, 'arn:taskDefinition')
+      .then((service) => {
+        expect(service).to.eql({ serviceName: 'serviceName' });
+        done();
+      });
   });
 
   describe('Wrap up', function () {
@@ -206,13 +206,13 @@ describe('ECS Service Image Updater', function () {
 
       ecsMock.on(RegisterTaskDefinitionCommand).callsFake((taskDefinition) => {
         expect(taskDefinition.taskDefinitionArn).to.equal('arn:updated');
-        return Promise.resolve({ taskDefinitionArn: 'arn:created' });
+        return Promise.resolve({ taskDefinition: { taskDefinitionArn: 'arn:created' } });
       });
 
-      updater.updateService = function (optionsSupplied, taskDefinitionArn, cb) {
+      updater.updateService = (optionsSupplied, taskDefinitionArn) => {
         expect(optionsSupplied).to.eql(options);
         expect(taskDefinitionArn).to.equal('arn:created');
-        cb(null, { taskDefinition: 'arn:created' });
+        return Promise.resolve({ taskDefinition: 'arn:created' });
       }
 
       const options = {


### PR DESCRIPTION
This PR isn't very big but unfortunately is a bit nasty to read because most of the functions are the same - they have just been promisified.

The main goal was to remove the use of the `async` library which we were only using to create a chain of functions, and a (probably unnecessary) parallel invocation of functions. Removing those usages while also keeping the callback facade around the newer AWS SDK was too much for my puny brain so I undertook to make all of the functions return promises instead - this has actually cleaned up a substantial amount of the logic anyway.

Functionally nothing has changed - one function was removed entirely (including its test) since it was just a callback facade around the AWS SDK. I also moved some of the checks for `serviceName` and `taskDefinitionFamily` into `getServiceTaskDefinition` and `getLatestActiveTaskDefinition` respectively, since it made the promise chaining more cumbersome than it needed to be, and fit nicely in those functions. The tests got a little simpler as a result, too.

I'm bumping the minor version again because the interface to this code if used as a library has changed substantially (if anyone is doing so).