### PR TITLE
[INF-2994] Bump to 0.3.1 for security updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bugcrowd/ecs-service-image-updater",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bugcrowd/ecs-service-image-updater",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ecs": "^3.454.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bugcrowd/ecs-service-image-updater",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Update an ECS service with a new Docker image",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Releases the fix for https://github.com/bugcrowd/ecs-service-image-updater/security/dependabot/13 and several other dependency bumps.